### PR TITLE
Update Webhooks logic so it will always look at first item in the array

### DIFF
--- a/src/main/kotlin/com/adyen/checkout/api/WebhookResource.kt
+++ b/src/main/kotlin/com/adyen/checkout/api/WebhookResource.kt
@@ -38,35 +38,35 @@ class WebhookResource @Autowired constructor(@Value("\${ADYEN_HMAC_KEY}") key: S
      */
     @PostMapping("/webhooks/notifications")
     fun webhooks(@RequestBody notificationRequest: NotificationRequest): ResponseEntity<String> {
-        notificationRequest.notificationItems.forEach(
-            Consumer { item: NotificationRequestItem ->
-                // We recommend validate HMAC signature in the webhooks for security reasons
-                try {
-                    if (HMACValidator().validateHMAC(item, hmacKey)) {
-                        log.info(
-                            """
-                                Received webhook with event {} :
-                                Merchant Reference: {}
-                                Alias : {}
-                                PSP reference : {}
-                                """.trimIndent(),
-                            item.eventCode,
-                            item.merchantReference,
-                            item.additionalData["alias"],
-                            item.pspReference
-                        )
-                    } else {
-//                         invalid HMAC signature: do not send [accepted] response
-                        log.warn("Could not validate HMAC signature for incoming webhook message: {}", item)
-                        throw RuntimeException("Invalid HMAC signature")
-                    }
-                } catch (e: SignatureException) {
-                    log.error("Error while validating HMAC Key", e)
+	// JSON and HTTP POST notifications always contain a single NotificationRequestItem object, see https://docs.adyen.com/development-resources/webhooks/understand-notifications#notification-structure
+        notificationRequest.notificationItems.firstOrNull()?.let { item: NotificationRequestItem ->
+            // We always recommend validating HMAC signature in the webhooks for security reasons, see https://docs.adyen.com/development-resources/webhooks/verify-hmac-signatures
+            try {
+                if (HMACValidator().validateHMAC(item, hmacKey)) {
+                    log.info(
+                        """
+                            Received webhook with event {} :
+                            Merchant Reference: {}
+                            Alias : {}
+                            PSP reference : {}
+                            """.trimIndent(),
+                        item.eventCode,
+                        item.merchantReference,
+                        item.additionalData["alias"],
+                        item.pspReference
+                    )
+                } else {
+                    // Invalid HMAC signature: do not send [accepted] response
+                    log.warn("Could not validate HMAC signature for incoming webhook message: {}", item)
+                    throw RuntimeException("Invalid HMAC signature")
                 }
+            } catch (e: SignatureException) {
+                log.error("Error while validating HMAC Key", e)
             }
-        )
+        }
+        
 
-        // Notifying the server we're accepting the payload
+        // Notifying the server that we've accepted the payload
         return ResponseEntity.ok().body("[accepted]")
     }
 }

--- a/src/main/kotlin/com/adyen/checkout/api/WebhookResource.kt
+++ b/src/main/kotlin/com/adyen/checkout/api/WebhookResource.kt
@@ -38,35 +38,38 @@ class WebhookResource @Autowired constructor(@Value("\${ADYEN_HMAC_KEY}") key: S
      */
     @PostMapping("/webhooks/notifications")
     fun webhooks(@RequestBody notificationRequest: NotificationRequest): ResponseEntity<String> {
-	// JSON and HTTP POST notifications always contain a single NotificationRequestItem object, see https://docs.adyen.com/development-resources/webhooks/understand-notifications#notification-structure
-        notificationRequest.notificationItems.firstOrNull()?.let { item: NotificationRequestItem ->
+        // JSON and HTTP POST notifications always contain a single NotificationRequestItem object
+        // See also https://docs.adyen.com/development-resources/webhooks/understand-notifications#notification-structure
+        notificationRequest.notificationItems.firstOrNull()?.let {
+            item: NotificationRequestItem ->
             // We always recommend validating HMAC signature in the webhooks for security reasons, see https://docs.adyen.com/development-resources/webhooks/verify-hmac-signatures
             try {
-                if (HMACValidator().validateHMAC(item, hmacKey)) {
-                    log.info(
-                        """
-                            Received webhook with event {} :
-                            Merchant Reference: {}
-                            Alias : {}
-                            PSP reference : {}
-                            """.trimIndent(),
-                        item.eventCode,
-                        item.merchantReference,
-                        item.additionalData["alias"],
-                        item.pspReference
-                    )
-                } else {
+                if (!HMACValidator().validateHMAC(item, hmacKey)) {
                     // Invalid HMAC signature: do not send [accepted] response
                     log.warn("Could not validate HMAC signature for incoming webhook message: {}", item)
                     throw RuntimeException("Invalid HMAC signature")
                 }
+
+                log.info(
+                    """
+                    Received webhook with event {} :
+                    Merchant Reference: {}
+                    Alias : {}
+                    PSP reference : {}
+                    """.trimIndent(),
+                    item.eventCode,
+                    item.merchantReference,
+                    item.additionalData["alias"],
+                    item.pspReference
+                )
+
+                // Notify the server that we've accepted the payload
+                return ResponseEntity.ok().body("[accepted]")
             } catch (e: SignatureException) {
                 log.error("Error while validating HMAC Key", e)
             }
-        }
-        
 
-        // Notifying the server that we've accepted the payload
-        return ResponseEntity.ok().body("[accepted]")
+            return ResponseEntity.badRequest().body("NotificationItems contains no items.");
+        }
     }
 }

--- a/src/main/kotlin/com/adyen/checkout/api/WebhookResource.kt
+++ b/src/main/kotlin/com/adyen/checkout/api/WebhookResource.kt
@@ -38,38 +38,35 @@ class WebhookResource @Autowired constructor(@Value("\${ADYEN_HMAC_KEY}") key: S
      */
     @PostMapping("/webhooks/notifications")
     fun webhooks(@RequestBody notificationRequest: NotificationRequest): ResponseEntity<String> {
-        // JSON and HTTP POST notifications always contain a single NotificationRequestItem object
-        // See also https://docs.adyen.com/development-resources/webhooks/understand-notifications#notification-structure
-        notificationRequest.notificationItems.firstOrNull()?.let {
-            item: NotificationRequestItem ->
+	// JSON and HTTP POST notifications always contain a single NotificationRequestItem object, see https://docs.adyen.com/development-resources/webhooks/understand-notifications#notification-structure
+        notificationRequest.notificationItems.firstOrNull()?.let { item: NotificationRequestItem ->
             // We always recommend validating HMAC signature in the webhooks for security reasons, see https://docs.adyen.com/development-resources/webhooks/verify-hmac-signatures
             try {
-                if (!HMACValidator().validateHMAC(item, hmacKey)) {
+                if (HMACValidator().validateHMAC(item, hmacKey)) {
+                    log.info(
+                        """
+                            Received webhook with event {} :
+                            Merchant Reference: {}
+                            Alias : {}
+                            PSP reference : {}
+                            """.trimIndent(),
+                        item.eventCode,
+                        item.merchantReference,
+                        item.additionalData["alias"],
+                        item.pspReference
+                    )
+                } else {
                     // Invalid HMAC signature: do not send [accepted] response
                     log.warn("Could not validate HMAC signature for incoming webhook message: {}", item)
                     throw RuntimeException("Invalid HMAC signature")
                 }
-
-                log.info(
-                    """
-                    Received webhook with event {} :
-                    Merchant Reference: {}
-                    Alias : {}
-                    PSP reference : {}
-                    """.trimIndent(),
-                    item.eventCode,
-                    item.merchantReference,
-                    item.additionalData["alias"],
-                    item.pspReference
-                )
-
-                // Notify the server that we've accepted the payload
-                return ResponseEntity.ok().body("[accepted]")
             } catch (e: SignatureException) {
                 log.error("Error while validating HMAC Key", e)
             }
-
-            return ResponseEntity.badRequest().body("NotificationItems contains no items.");
         }
+        
+
+        // Notifying the server that we've accepted the payload
+        return ResponseEntity.ok().body("[accepted]")
     }
 }

--- a/src/main/kotlin/com/adyen/checkout/api/WebhookResource.kt
+++ b/src/main/kotlin/com/adyen/checkout/api/WebhookResource.kt
@@ -41,15 +41,15 @@ class WebhookResource @Autowired constructor(@Value("\${ADYEN_HMAC_KEY}") key: S
 	// JSON and HTTP POST notifications always contain a single NotificationRequestItem object
 	// See also https://docs.adyen.com/development-resources/webhooks/understand-notifications#notification-structure
         notificationRequest.notificationItems.firstOrNull()?.let { item: NotificationRequestItem ->
-            // We always recommend validating HMAC signature in the webhooks for security reasons, see https://docs.adyen.com/development-resources/webhooks/verify-hmac-signatures
             try {
+                // We always recommend validating HMAC signature in the webhooks for security reasons, see https://docs.adyen.com/development-resources/webhooks/verify-hmac-signatures
                 if (!HMACValidator().validateHMAC(item, hmacKey)) {
                     // Invalid HMAC signature: do not send [accepted] response
                     log.warn("Could not validate HMAC signature for incoming webhook message: {}", item)
                     throw RuntimeException("Invalid HMAC signature")
                 }
 
-                // Process the notification here
+                // Process the notification here, in this case we log it
                 log.info(
                     """
                         Received webhook with event {} :
@@ -62,6 +62,7 @@ class WebhookResource @Autowired constructor(@Value("\${ADYEN_HMAC_KEY}") key: S
                     item.additionalData["alias"],
                     item.pspReference
                 )
+
                 // Notify the server that we've accepted the payload
                 return ResponseEntity.ok().body("[accepted]")
             } catch (e: SignatureException) {

--- a/src/main/kotlin/com/adyen/checkout/api/WebhookResource.kt
+++ b/src/main/kotlin/com/adyen/checkout/api/WebhookResource.kt
@@ -38,8 +38,8 @@ class WebhookResource @Autowired constructor(@Value("\${ADYEN_HMAC_KEY}") key: S
      */
     @PostMapping("/webhooks/notifications")
     fun webhooks(@RequestBody notificationRequest: NotificationRequest): ResponseEntity<String> {
-	// JSON and HTTP POST notifications always contain a single NotificationRequestItem object
-	// See also https://docs.adyen.com/development-resources/webhooks/understand-notifications#notification-structure
+	    // JSON and HTTP POST notifications always contain a single NotificationRequestItem object
+	    // See also https://docs.adyen.com/development-resources/webhooks/understand-notifications#notification-structure
         notificationRequest.notificationItems.firstOrNull()?.let { item: NotificationRequestItem ->
             try {
                 // We always recommend validating HMAC signature in the webhooks for security reasons, see https://docs.adyen.com/development-resources/webhooks/verify-hmac-signatures


### PR DESCRIPTION
Process first and only element in the NotificationItems array.

See [documentation](https://docs.adyen.com/development-resources/webhooks/understand-notifications#notification-structure).

> JSON and HTTP POST notifications always contain a single NotificationRequestItem object.
SOAP notifications may contain up to six NotificationRequestItem objects, in case the events triggering notifications happen within a very short period of time.


**Acceptance Criteria**
- Process first and only element in the NotificationItems array.