### PR TITLE
Webhook processing: 202 response with empty body

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,8 +3,21 @@ name: E2E (Playwright)
 on:
   workflow_dispatch:
   push:
+    branches: [ main ]
+    paths-ignore:
+      - '**/README.md'
+      - README.md
+      - .gitignore
+      - .gitpod.yml
+      - LICENSE
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - '**/README.md'
+      - README.md
+      - .gitignore
+      - .gitpod.yml
+      - LICENSE
 
 jobs:
   checkout:

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 env.tmp
+application-dev.properties
 
 ### STS ###
 .apt_generated

--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,3 +1,3 @@
 # Enable auto-env through the sdkman_auto_env config
 # Add key=value pairs of SDKs to use below
-java=11.0.14-librca
+java=17.0.2-zulu


### PR DESCRIPTION
The latest approach to accepting webhooks requires sending the response code `202` and an empty response body.

This PR updates all webhook handlers to implement the new approach.