### PR TITLE
Upgrade to iDEAL 2.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,9 +25,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 17

--- a/src/main/resources/templates/layout.html
+++ b/src/main/resources/templates/layout.html
@@ -21,15 +21,15 @@
     />
 
     <!-- Adyen JS from TEST environment (change to live for production) -->
-    <script src="https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/5.40.0/adyen.js"
-            integrity="sha384-ds1t0hgFCe636DXFRL6ciadL2Wb4Yihh27R4JO7d9CF7sFY3NJE4aPCK0EpzaYXD"
-            crossorigin="anonymous"></script>
+    <script src="https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/5.68.0/adyen.js"
+      integrity="sha384-U9GX6Oa3W024049K86PYG36/jHjkvUqsRd8Y9cF1CmB92sm4tnjxDXF/tkdcsk6k"
+      crossorigin="anonymous"></script>
 
     <!-- Adyen CSS from TEST environment (change to live for production)-->
     <link rel="stylesheet"
-          href="https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/5.40.0/adyen.css"
-          integrity="sha384-BRZCzbS8n6hZVj8BESE6thGk0zSkUZfUWxL/vhocKu12k3NZ7xpNsIK39O2aWuni"
-          crossorigin="anonymous">
+      href="https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/5.68.0/adyen.css"
+      integrity="sha384-gpOE6R0K50VgXe6u/pyjzkKl4Kr8hXu93KUCTmC4LqbO9mpoGUYsrmeVLcp2eejn"
+      crossorigin="anonymous">
 
     <link rel="stylesheet" href="/css/application.css" />
   </head>


### PR DESCRIPTION
Support iDEAL 2.0.

Changes required: update to `Drop-in v5.68.0`

### Note 

- on **TEST** the iDEAL payment method in the Customer Area must be updated to use the `AdyenIdeal` acquirer
- on **LIVE** no changes are required in the Customer Area